### PR TITLE
Typo fix

### DIFF
--- a/vscripts/Utilities.lua
+++ b/vscripts/Utilities.lua
@@ -8,7 +8,7 @@ local heroNames = require('HeroNames')
 -- sweet DeepPrint function I cadged from GitHub
 local inspect = require('inspect')
 
-if Utulities == nil then
+if Utilities == nil then
 	Utilities = 
 	{
 		listeners = 


### PR DESCRIPTION
Nothing spectatular - on a cursory look, I saw `Utilities` was mispelled in the Utilities.lua
I figured it might matter.