### PR TITLE
Added neutral timings scaling with difficulty

### DIFF
--- a/vscripts/SettingsDefault.lua
+++ b/vscripts/SettingsDefault.lua
@@ -62,8 +62,10 @@
 			-- adds this number to the awards as they come out (make this positive to give better items early
 			-- make it negative to cause errors, probably.  If you want slower items just change the timings)
 			tierOffset = 0,
-			-- game time (seconds) at which awards are given.  
+			-- game time (seconds) at which awards are given.
 			timings = {0, 420, 1020, 2020, 3600},
+			-- default dota values, see NeutralItems:GetTimingDifficultyScaleShift()
+			timingsDefault = {420, 1020, 1620, 2020, 3600},
 			-- variance for timings (this number of seconds added to base timing per bot)
 			variance = {30, 240},
 			-- if true, announce awards to chat


### PR DESCRIPTION
- Added settings for dota2 default neutral timings
- Added ability to linearly interpolate between bot baseline neutral timings (which are aggressive) as difficultyScale 1.0 and dota2 default neutral timings

The general behavior given how balance is tweaked now is that at lower difficulty scales we should see bots get their neutrals slightly later for tiers 1-3. At difficultyScale 1.0 (people would need to vote 5), we're back to normal. At higher difficulties the timings for tiers 1-3 will be even **MORE** aggressive.

	Rough reference using timings = {0, 420, 1020, 2020, 3600}: (these are bot defaults, and tiers 4 and 5 match dota defaults)
	| Tier          | 1         | 2    | 3    | 4    | 5    |
	|---------------|-----------|------|------|------|------|
	| 0 (base game) | 420       | 1020 | 1620 | 2020 | 3600 |
	| 0.5           | 210       | 720  | 1320 | 2020 | 3600 |
	| 0.7           | 126       | 600  | 1200 | 2020 | 3600 |
	| 1             | 0         | 420  | 1020 | 2020 | 3600 |
	| 1.5           | 0 (clamp) | 120  | 720  | 2020 | 3600 |